### PR TITLE
Fix typo and type error in tflocoformer_separator.py

### DIFF
--- a/espnet2/enh/separator/tflocoformer_separator.py
+++ b/espnet2/enh/separator/tflocoformer_separator.py
@@ -70,7 +70,7 @@ class TFLocoformerSeparator(AbsSeparator):
         n_layers: int = 6,
         # general setup
         emb_dim: int = 128,
-        norm_type: str = "rmsgrouporm",
+        norm_type: str = "rmsgroupnorm",
         num_groups: int = 4,  # used only in RMSGroupNorm
         tf_order: str = "ft",
         # self-attention related

--- a/espnet2/enh/separator/tflocoformer_separator.py
+++ b/espnet2/enh/separator/tflocoformer_separator.py
@@ -324,6 +324,9 @@ class LocoformerBlock(nn.Module):
             assert (
                 isinstance(ffn_hidden_dim, list) and len(ffn_hidden_dim) == 2
             ), "Two FFNs required when using Macaron-style model"
+        else:
+            ffn_type = [ffn_type]
+            ffn_hidden_dim = [ffn_hidden_dim]
 
         # initialize FFN
         self.ffn_norm = nn.ModuleList([])


### PR DESCRIPTION
1. Fix typo for default variable of 'norm_type'.
2. ffn_type and ffn_hidden_dim should be list, working for loop iteration on next line.